### PR TITLE
Adding see full schedule/hide full schedule toggle feature

### DIFF
--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -160,10 +160,10 @@ export default function Schedule() {
                 </tr>
                 </thead>
 		   <tbody>
-		       <tr> { flatSchedule[lastDeparture] } </tr>
-		       <tr> { flatSchedule[lastDeparture+1] } </tr>
-		       <tr> { flatSchedule[lastDeparture+2] } </tr>
-		       <tr> { flatSchedule[lastDeparture+3] } </tr>
+		       <tr> <td> { flatSchedule[lastDeparture] } </td> </tr>
+		       <tr> <td> { flatSchedule[lastDeparture+1] } </td> </tr>
+		       <tr> <td> { flatSchedule[lastDeparture+2] } </td> </tr>
+		       <tr> <td> { flatSchedule[lastDeparture+3] } </td>  </tr>
 		 </tbody>
 		 </table>
 		   }	

--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 
+
 export default function Schedule() {
 
     // schedules store the times for each shuttle
@@ -69,8 +70,12 @@ export default function Schedule() {
         '16:00',
     ]
 
-    const today = new Date();
-    const [day, setDay] = useState(today.getDay());
+    const [fullSchedule, setFullSchedule] = useState(false);
+    const handleViewToggle = () => {
+	setFullSchedule(prevView => !prevView)
+    }
+
+    const [day, setDay] = useState(0);
     const handleDayChange = (e) => {
         setDay(parseInt(e.target.value));
     }
@@ -81,6 +86,32 @@ export default function Schedule() {
 
     // Flatten the schedule for display
     const flatSchedule = schedule.flat().sort();
+
+    // Converting Date object into String comparable with format 'HH:MM'
+    const now = new Date();
+    let currentHours = now.getHours();
+    let currentMinutes = now.getMinutes();
+    const formattedHours = currentHours < 10 ? '0' + currentHours : String(currentHours);
+    const formattedMinutes = currentMinutes < 10 ? '0' + currentMinutes : String(currentMinutes);
+    const currentTimeString = formattedHours + ":" + formattedMinutes;
+
+    // Binary searching for last departure
+
+    let lastDeparture = flatSchedule.length - 1;
+    if (currentTimeString <= flatSchedule[lastDeparture]) {
+	let low = 0;
+	let high = lastDeparture;
+	while (low <= high) {
+	    let mid = Math.floor((low+high)/2);
+	    if (currentTimeString <= flatSchedule[mid + 1]) {
+		lastDeparture = mid;
+		high = mid - 1;
+	    }
+	    else {
+		low = mid + 1;
+	    }
+	}
+    }
 
     return (
         <>
@@ -101,6 +132,8 @@ export default function Schedule() {
                     }
                 </select>
             </p>
+
+	    {fullSchedule ?
             <table>
                 <thead>
                 <tr>
@@ -117,6 +150,25 @@ export default function Schedule() {
                 }
                 </tbody>
             </table>
+
+	     : <table>
+		<thead>
+                <tr>
+                    <th className="">Time</th>
+                </tr>
+                </thead>
+		   <tbody>
+		       <tr> { flatSchedule[lastDeparture] } </tr>
+		       <tr> { flatSchedule[lastDeparture+1] } </tr>
+		       <tr> { flatSchedule[lastDeparture+2] } </tr>
+		       <tr> { flatSchedule[lastDeparture+3] } </tr>
+		 </tbody>
+		 </table>
+		   }	
+	    <button
+		onClick={handleViewToggle}>
+		{fullSchedule ? '...hide full schedule' : '...see full schedule'}
+	    </button>
             </div>
         </>
     );

--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -115,6 +115,13 @@ export default function Schedule() {
 	}
     }
 
+    const buttonStyle = {
+	backgroundColor: 'transparent',
+	border: 'none',
+	color: '#206ef9',
+	fontStyle: 'italic',
+    };
+
     return (
         <>
         <div className="p-4">
@@ -168,6 +175,7 @@ export default function Schedule() {
 		 </table>
 		   }	
 	    <button
+		style = {buttonStyle}
 		onClick={handleViewToggle}>
 		{fullSchedule ? '...hide full schedule' : '...see full schedule'}
 	    </button>

--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -70,12 +70,14 @@ export default function Schedule() {
         '16:00',
     ]
 
+    const today = new Date();
+    const [day, setDay] = useState(today.getDay());
+
     const [fullSchedule, setFullSchedule] = useState(false);
     const handleViewToggle = () => {
 	setFullSchedule(prevView => !prevView)
     }
 
-    const [day, setDay] = useState(0);
     const handleDayChange = (e) => {
         setDay(parseInt(e.target.value));
     }
@@ -89,8 +91,8 @@ export default function Schedule() {
 
     // Converting Date object into String comparable with format 'HH:MM'
     const now = new Date();
-    let currentHours = now.getHours();
-    let currentMinutes = now.getMinutes();
+    const currentHours = now.getHours();
+    const currentMinutes = now.getMinutes();
     const formattedHours = currentHours < 10 ? '0' + currentHours : String(currentHours);
     const formattedMinutes = currentMinutes < 10 ? '0' + currentMinutes : String(currentMinutes);
     const currentTimeString = formattedHours + ":" + formattedMinutes;

--- a/client/src/pages/Schedule.jsx
+++ b/client/src/pages/Schedule.jsx
@@ -160,10 +160,10 @@ export default function Schedule() {
                 </tr>
                 </thead>
 		   <tbody>
-		       <tr> <td> { flatSchedule[lastDeparture] } </td> </tr>
-		       <tr> <td> { flatSchedule[lastDeparture+1] } </td> </tr>
-		       <tr> <td> { flatSchedule[lastDeparture+2] } </td> </tr>
-		       <tr> <td> { flatSchedule[lastDeparture+3] } </td>  </tr>
+		       <tr><td>{ flatSchedule[lastDeparture] }</td></tr>
+		       <tr><td>{ flatSchedule[lastDeparture+1] }</td></tr>
+		       <tr><td>{ flatSchedule[lastDeparture+2] }</td></tr>
+		       <tr><td>{ flatSchedule[lastDeparture+3] }</td></tr>
 		 </tbody>
 		 </table>
 		   }	


### PR DESCRIPTION
I created a stated boolean fullSchedule and used the ternary operator to display the full schedule or the default shortened schedule (most recent departure and next three) conditionally. In order to locate the most recent departure in flatSchedule, I converted the current Date() into the String format "HH:MM" and used binary search. Finally, I displayed a button at the bottom of the table of departure times to allow users to toggle between the shortened and full schedule. 

Below are screenshots of the two displays on my MacBook:
<img width="1440" alt="full_schedule_display" src="https://github.com/user-attachments/assets/fc32701a-93be-4b9f-b6c5-7da9474d99bf" />

<img width="1440" alt="shortened_schedule_display" src="https://github.com/user-attachments/assets/cd96aa20-5d1b-4c6d-89f0-8a720d5df899" />