### PR TITLE
Adding schedule to the side of Live Location map for wide screens

### DIFF
--- a/client/src/pages/LiveLocation.css
+++ b/client/src/pages/LiveLocation.css
@@ -1,15 +1,15 @@
-.LiveLocation-div {
+.live-location-div {
     display: flex;
     flex-direction: row;
     gap: 20px;
 }
 
-.scheduleTable {
+.schedule-table {
     display: none;
 }
 
 @media (min-width: 1024px) {
-    .scheduleTable {
+    .schedule-table {
 	display: block;
     }
 }

--- a/client/src/pages/LiveLocation.css
+++ b/client/src/pages/LiveLocation.css
@@ -1,7 +1,7 @@
 .live-location-div {
     display: flex;
     flex-direction: row;
-    gap: 20px;
+    gap: 40px;
 }
 
 .schedule-table {

--- a/client/src/pages/LiveLocation.css
+++ b/client/src/pages/LiveLocation.css
@@ -1,0 +1,16 @@
+.LiveLocation-div {
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
+}
+
+.scheduleTable {
+    display: none;
+}
+
+@media (min-width: 1024px) {
+    .scheduleTable {
+	display: block;
+    }
+}
+

--- a/client/src/pages/LiveLocation.jsx
+++ b/client/src/pages/LiveLocation.jsx
@@ -38,9 +38,9 @@ export default function LiveLocation() {
     }, []);
 
     return (
-	<div className = "LiveLocation-div">
+	<div className = "live-location-div">
 	    <MapKitMap vehicles={ location } />
-	    <div className = "scheduleTable">
+	    <div className = "schedule-table">
 		<Schedule />
 	    </div>
 	</div>

--- a/client/src/pages/LiveLocation.jsx
+++ b/client/src/pages/LiveLocation.jsx
@@ -2,7 +2,10 @@ import React, {
     useState,
     useEffect,
 } from 'react';
+
 import MapKitMap from '../components/MapKitMap';
+import Schedule from './Schedule';
+import "./LiveLocation.css";
 
 export default function LiveLocation() {
 
@@ -35,6 +38,11 @@ export default function LiveLocation() {
     }, []);
 
     return (
-        <MapKitMap vehicles={ location }/>
-    )
+	<div className = "LiveLocation-div">
+	    <MapKitMap vehicles={ location } />
+	    <div className = "scheduleTable">
+		<Schedule />
+	    </div>
+	</div>
+    );
 }


### PR DESCRIPTION
I imported and rendered a div Schedule in LiveLocation.jsx and styled it in a new file I added called LiveLocation.css. I used min-width media queries to display the schedule to the right of the map in a flexbox when the screen is large enough (> 1024px).

Here are screenshots simulating a full screen MacBook vs. an iPhone:

<img width="400" alt="iphone_side_schedule" src="https://github.com/user-attachments/assets/bbdb8f47-590f-4c7e-a147-f860e2e958b6" />
<img width="1440" alt="fullscreen_macbook_side_schedule" src="https://github.com/user-attachments/assets/4661b2e8-10b4-45e9-877d-9599b840b4da" />

I've never actually seen the map locally on my MacBook, just that gray box. It was only when I visited the real website while writing this description that I realized there was an actual map at all. I am also not sure why even the gray box won't show for the iPhone sized display.