### PR TITLE
Fixing lack of map on iphone live location display

### DIFF
--- a/client/src/pages/LiveLocation.css
+++ b/client/src/pages/LiveLocation.css
@@ -2,11 +2,15 @@
     display: flex;
     flex-direction: row;
     gap: 40px;
+    width: 100%;
+    justify-content: center;
+    
 }
 
 .schedule-table {
     display: none;
 }
+
 
 @media (min-width: 1024px) {
     .schedule-table {


### PR DESCRIPTION
The problem with my previous method was that the lack of minimum width on the flexbox containing the live locaiton map (and the schedule for larger screens) allowed the live location map to shrink to zero width on the iphone sized screen display. I solved this by setting the width of the flexbox to be 100%, and then also styled it to centered its elements on the screen. 

New and improved screenshots of three sized screens can be seen below:
<img width="443" alt="Screenshot 2025-06-09 at 9 44 37 AM" src="https://github.com/user-attachments/assets/2c24af0e-4116-42f4-8661-77455f3a211b" />
<img width="724" alt="Screenshot 2025-06-09 at 9 44 12 AM" src="https://github.com/user-attachments/assets/7aa43936-9dd9-4640-8a35-009492993e12" />
<img width="1440" alt="Screenshot 2025-06-09 at 9 43 50 AM" src="https://github.com/user-attachments/assets/67a02508-2e04-41a8-bca5-0605f228f33d" />
