### PR TITLE
Setting up Shubble data page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -9,6 +9,7 @@ import LiveLocation from './pages/LiveLocation';
 import Schedule from './pages/Schedule';
 import About from './pages/About';
 import Feedback from './components/Feedback';
+import Data from './pages/Data';
 
 function App() {
   return (
@@ -40,6 +41,7 @@ function App() {
           <Route path='/' element={ <LiveLocation /> } />
           <Route path='/schedule' element={ <Schedule /> } />
           <Route path='/about' element={ <About /> } />
+	  <Route path='/data' element={ <Data /> } />
         </Routes>
         <div class='small feedback-container'>
           <Feedback />

--- a/client/src/pages/About.jsx
+++ b/client/src/pages/About.jsx
@@ -3,6 +3,9 @@ import {
     useState,
     useEffect,
 } from 'react';
+import {
+    Link
+} from 'react-router';
 
 export default function About() {
 
@@ -29,6 +32,10 @@ export default function About() {
             <p>
                 Have an idea to improve it? Contributions are welcome. Visit our <a href='https://github.com/wtg/shubble' target='_blank'>Github Repository</a> to learn more.
             </p>
+	    <p>
+		Interested in Shubble's data? Take a look at our <Link to='/data'> <span>data page</span>
+								 </Link>.
+	    </p>
             <div className='small'>
                 <p>
                     &copy; 2025 SHUBBLE

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -1,0 +1,7 @@
+export default function Data() {
+    return (
+	<p>
+	    This is the data page!
+	</p>
+    );
+}


### PR DESCRIPTION
I created a page at /data in App.jsx and made a Data.jsx file to render the Data page. I then added a short blurb with a link to the Data page on the About page, which can be seen below.

<img width="1440" alt="Screenshot 2025-06-12 at 10 07 15 AM" src="https://github.com/user-attachments/assets/d31a4a76-2587-4779-8efb-14a6463eee7d" />
