### PR TITLE
Setting up dropdown menu and table on Data page

### DIFF
--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -42,43 +42,47 @@ export default function Data() {
 		<p>Here you can view location history by shuttle.</p>
 	    </div>
 
-	    <p className = "dropdown">
-		Shuttle:
-		<select value={shuttle} onChange={handleShuttleChange}>
-		    {
-			shuttleList.map((shuttle, index) =>
-			<option key={index} vlaue={index}>
-			    {shuttle.id}
-			</option>
-			)
-		    }	
-		</select>
-	    </p>
-	    <table className = "table">
-		<thead>
-		    <tr>
-			<th>
-			    Timestamp
-			</th>
-			<th>
-			    Location
-			</th>
-			<th>
-			    Speed
-			</th>
-		    </tr>
-		</thead>
-		<tbody>
-		    {shuttleList.map((shuttle, index) => (
-		    <tr key={index}>
-			<td>{shuttle.timestamp}</td>
-			<td>{shuttle.lat}, {shuttle.lng}</td>
-			<td>{shuttle.speed} mph</td>
-		    </tr>
-		    ))}
-		</tbody>
-	    </table>
-	    <MapKitMap vehicles={ location } />
+	    <div className = "table-map-sidebyside">
+		<div>
+		<p>
+		    Shuttle:
+		    <select value={shuttle} onChange={handleShuttleChange}>
+			{
+			    shuttleList.map((shuttle, index) =>
+				<option key={index} vlaue={index}>
+				    {shuttle.id}
+				</option>
+			    )
+			}	
+		    </select>
+		</p>
+		<table className = "data-table">
+		    <thead>
+			<tr>
+			    <th>
+				Timestamp
+			    </th>
+			    <th>
+				Location
+			    </th>
+			    <th>
+				Speed
+			    </th>
+			</tr>
+		    </thead>
+		    <tbody>
+			{shuttleList.map((shuttle, index) => (
+			    <tr key={index}>
+				<td>{shuttle.timestamp}</td>
+				<td>{shuttle.lat}, {shuttle.lng}</td>
+				<td>{shuttle.speed} mph</td>
+			    </tr>
+			))}
+		    </tbody>
+		</table>
+		</div>
+		<MapKitMap vehicles={ location } />
+	    </div>
 	</>
     );
 }

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -52,7 +52,31 @@ export default function Data() {
 			)
 		    }	
 		</select>
-	    </p>   
+	    </p>
+	    <table className = "table">
+		<thead>
+		    <tr>
+			<th>
+			    Timestamp
+			</th>
+			<th>
+			    Location
+			</th>
+			<th>
+			    Speed
+			</th>
+		    </tr>
+		</thead>
+		<tbody>
+		    {shuttleList.map((shuttle, index) => (
+		    <tr key={index}>
+			<td>{shuttle.timestamp}</td>
+			<td>{shuttle.lat}, {shuttle.lng}</td>
+			<td>{shuttle.speed} mph</td>
+		    </tr>
+		    ))}
+		</tbody>
+	    </table>
 	</>
     );
 }

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -1,12 +1,58 @@
+import { useState } from 'react';
 import "../styles/Data.css"
 
 export default function Data() {
+
+    // made up shuttle data
+    const shuttleList = [
+	{id: 0,
+         lat: 0,
+         lng: 0,
+         timestamp: 0,
+         speed: 0,
+         heading: "N",
+	 address: "zero"},
+	{id: 1,
+         lat: 1,
+         lng: 1,
+         timestamp: 1,
+         speed: 1,
+         heading: "N",
+	 address: "one"},
+	{id: 2,
+         lat: 2,
+         lng: 2,
+         timestamp: 2,
+         speed: 2,
+         heading: "N",
+	 address: "two"}			  
+    ];
+
+    const [shuttle, setShuttle] = useState(shuttleList[0]);
+    const handleShuttleChange = (e) => {
+	setShuttle(parseInt(event.target.value));
+    }
+
+    
     return (
 	<>
 	    <div className = "header">
 		<h1>Shubble Data</h1>
 		<p>Here you can view location history by shuttle.</p>
 	    </div>
+
+	    <p className = "dropdown">
+		Shuttle:
+		<select value={shuttle} onChange={handleShuttleChange}>
+		    {
+			shuttleList.map((shuttle, index) =>
+			<option key={index} vlaue={index}>
+			    {shuttle.id}
+			</option>
+			)
+		    }	
+		</select>
+	    </p>   
 	</>
     );
 }

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -5,36 +5,38 @@ import MapKitMap from '../components/MapKitMap';
 export default function Data() {
 
     // made up shuttle data
-    const shuttleList = [
-	{id: 0,
-         lat: 0,
-         lng: 0,
-         timestamp: "2020-07-03T02:11:51Z",
-         speed: 0,
-         heading: "N",
-	 address: "zero"},
-	{id: 1,
-         lat: 1,
-         lng: 1,
-         timestamp: "2020-07-03T12:11:51Z",
-         speed: 1,
-         heading: "E",
-	 address: "one"},
-	{id: 2,
-         lat: 2,
-         lng: 2,
-         timestamp: "2020-07-03T22:11:51Z",
-         speed: 2,
-         heading: "S",
-	 address: "two"}			  
-    ];
+    const shuttleList = {
+	"shuttleID1": {
+	    lat: 0,
+            lng: 0,
+            timestamp: "2020-07-03T02:11:51Z",
+            speed: 0,
+            heading: "N",
+	    address: "zero"
+	},
+	"shuttleID2": {
+            lat: 1,
+            lng: 1,
+            timestamp: "2020-07-03T12:11:51Z",
+            speed: 1,
+            heading: "E",
+	    address: "one"
+	},
+	"shuttleID3": {
+            lat: 2,
+            lng: 2,
+            timestamp: "2020-07-03T22:11:51Z",
+            speed: 2,
+            heading: "S",
+	    address: "two"
+	}
+    };
 
-    const [shuttle, setShuttle] = useState(shuttleList[0]);
+    const [shuttleID, setShuttleID] = useState("shuttleID1");
     const handleShuttleChange = (event) => {
-	setShuttle(shuttleList[parseInt(event.target.value)]);
+	setShuttleID(event.target.value);
     }
 
-    
     return (
 	<>
 	    <div className = "header">
@@ -46,12 +48,12 @@ export default function Data() {
 		<div>
 		    <p>
 			Shuttle:
-			<select value={shuttle.id} onChange={handleShuttleChange}>
-			    {shuttleList.map(shuttle => (
-				<option key={shuttle.id} value={shuttle.id}>
-				    {shuttle.address}
+			<select value={shuttleID} onChange={handleShuttleChange}>
+			    {Object.keys(shuttleList).map(shuttleID => (
+				<option key={shuttleID} value={shuttleID}>
+				    {shuttleID}
 				</option>
-			    ))}	
+			    ))}
 			</select>
 		    </p>
 
@@ -70,10 +72,10 @@ export default function Data() {
 			    </tr>
 			</thead>
 			<tbody>
-			    <tr>
-				<td>{((shuttle.timestamp.substring(11, 12) === "0") ? shuttle.timestamp.substring(12, 19) : shuttle.timestamp.substring(11, 19))}</td>
-				<td>{shuttle.lat}, {shuttle.lng}</td>
-				<td>{shuttle.speed} mph</td>
+			    <tr> 
+				<td>{((shuttleList[shuttleID].timestamp.substring(11, 12) === "0") ? shuttleList[shuttleID].timestamp.substring(12, 19) : shuttleList[shuttleID].timestamp.substring(11, 19))}</td>
+				<td>{shuttleList[shuttleID].lat}, {shuttleList[shuttleID].lng}</td>
+				<td>{shuttleList[shuttleID].speed} mph</td>
 			    </tr>
 			</tbody>
 		    </table>

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -9,29 +9,29 @@ export default function Data() {
 	{id: 0,
          lat: 0,
          lng: 0,
-         timestamp: 0,
+         timestamp: "Timestamp1",
          speed: 0,
          heading: "N",
 	 address: "zero"},
 	{id: 1,
          lat: 1,
          lng: 1,
-         timestamp: 1,
+         timestamp: "Timestamp2",
          speed: 1,
-         heading: "N",
+         heading: "E",
 	 address: "one"},
 	{id: 2,
          lat: 2,
          lng: 2,
-         timestamp: 2,
+         timestamp: "Timestamp3",
          speed: 2,
-         heading: "N",
+         heading: "S",
 	 address: "two"}			  
     ];
 
     const [shuttle, setShuttle] = useState(shuttleList[0]);
-    const handleShuttleChange = (e) => {
-	setShuttle(parseInt(event.target.value));
+    const handleShuttleChange = (event) => {
+	setShuttle(shuttleList[parseInt(event.target.value)]);
     }
 
     
@@ -44,42 +44,39 @@ export default function Data() {
 
 	    <div className = "table-map-sidebyside">
 		<div>
-		<p>
-		    Shuttle:
-		    <select value={shuttle} onChange={handleShuttleChange}>
-			{
-			    shuttleList.map((shuttle, index) =>
-				<option key={index} vlaue={index}>
-				    {shuttle.id}
+		    <p>
+			Shuttle:
+			<select value={shuttle.id} onChange={handleShuttleChange}>
+			    {shuttleList.map(shuttle => (
+				<option key={shuttle.id} value={shuttle.id}>
+				    {shuttle.address}
 				</option>
-			    )
-			}	
-		    </select>
-		</p>
-		<table className = "data-table">
-		    <thead>
-			<tr>
-			    <th>
-				Timestamp
-			    </th>
-			    <th>
-				Location
-			    </th>
-			    <th>
-				Speed
-			    </th>
-			</tr>
-		    </thead>
-		    <tbody>
-			{shuttleList.map((shuttle, index) => (
-			    <tr key={index}>
+			    ))}	
+			</select>
+		    </p>
+
+		    <table className = "data-table">
+			<thead>
+			    <tr>
+				<th>
+				    Timestamp
+				</th>
+				<th>
+				    Location
+				</th>
+				<th>
+				    Speed
+				</th>
+			    </tr>
+			</thead>
+			<tbody>
+			    <tr>
 				<td>{shuttle.timestamp}</td>
 				<td>{shuttle.lat}, {shuttle.lng}</td>
 				<td>{shuttle.speed} mph</td>
 			    </tr>
-			))}
-		    </tbody>
-		</table>
+			</tbody>
+		    </table>
 		</div>
 		<MapKitMap vehicles={ location } />
 	    </div>

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -9,21 +9,21 @@ export default function Data() {
 	{id: 0,
          lat: 0,
          lng: 0,
-         timestamp: "Timestamp1",
+         timestamp: "2020-07-03T02:11:51Z",
          speed: 0,
          heading: "N",
 	 address: "zero"},
 	{id: 1,
          lat: 1,
          lng: 1,
-         timestamp: "Timestamp2",
+         timestamp: "2020-07-03T12:11:51Z",
          speed: 1,
          heading: "E",
 	 address: "one"},
 	{id: 2,
          lat: 2,
          lng: 2,
-         timestamp: "Timestamp3",
+         timestamp: "2020-07-03T22:11:51Z",
          speed: 2,
          heading: "S",
 	 address: "two"}			  
@@ -71,7 +71,7 @@ export default function Data() {
 			</thead>
 			<tbody>
 			    <tr>
-				<td>{shuttle.timestamp}</td>
+				<td>{((shuttle.timestamp.substring(11, 12) === "0") ? shuttle.timestamp.substring(12, 19) : shuttle.timestamp.substring(11, 19))}</td>
 				<td>{shuttle.lat}, {shuttle.lng}</td>
 				<td>{shuttle.speed} mph</td>
 			    </tr>

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -64,7 +64,7 @@ export default function Data() {
 				    Timestamp
 				</th>
 				<th>
-				    Location
+				    Latitude, Longitude
 				</th>
 				<th>
 				    Speed

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import "../styles/Data.css"
+import MapKitMap from '../components/MapKitMap';
 
 export default function Data() {
 
@@ -77,6 +78,7 @@ export default function Data() {
 		    ))}
 		</tbody>
 	    </table>
+	    <MapKitMap vehicles={ location } />
 	</>
     );
 }

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -1,7 +1,12 @@
+import "../styles/Data.css"
+
 export default function Data() {
     return (
-	<p>
-	    This is the data page!
-	</p>
+	<>
+	    <div className = "header">
+		<h1>Shubble Data</h1>
+		<p>Here you can view location history by shuttle.</p>
+	    </div>
+	</>
     );
 }

--- a/client/src/styles/Data.css
+++ b/client/src/styles/Data.css
@@ -1,21 +1,15 @@
 .header {
-    position: absolute;
     text-align: left;
-    top: 100px;
-    left: 50px;
+    width: 100%;
+    margin-left: 100px;
 }
 
-.dropdown {
-    position: absolute;
-    text-align: left;
-    top: 200px;
-    left: 50px;
+.data-table {
+    width: 30vw;
 }
 
-.table {
-    position: absolute;
-    top: 300px;
-    left: 50px;
-    border-spacing: 10px;
-    width: 100px;
+.table-map-sidebyside {
+    display: flex;
+    flex-direction: row;
+    gap: 50px;
 }

--- a/client/src/styles/Data.css
+++ b/client/src/styles/Data.css
@@ -11,3 +11,11 @@
     top: 200px;
     left: 50px;
 }
+
+.table {
+    position: absolute;
+    top: 300px;
+    left: 50px;
+    border-spacing: 10px;
+    width: 100px;
+}

--- a/client/src/styles/Data.css
+++ b/client/src/styles/Data.css
@@ -1,7 +1,5 @@
 .header {
-    text-align: left;
-    width: 100%;
-    margin-left: 100px;
+    width: 90%;
 }
 
 .data-table {
@@ -12,4 +10,16 @@
     display: flex;
     flex-direction: row;
     gap: 50px;
+    width: 90%;
+}
+
+@media (max-width: 768px){
+    .table-map-sidebyside {
+	flex-direction: column-reverse;
+    }
+
+    .data-table {
+	width: 80vw;
+    }
+    
 }

--- a/client/src/styles/Data.css
+++ b/client/src/styles/Data.css
@@ -1,0 +1,6 @@
+.header {
+    position: absolute;
+    text-align: left;
+    top: 100px;
+    left: 50px;
+}

--- a/client/src/styles/Data.css
+++ b/client/src/styles/Data.css
@@ -4,3 +4,10 @@
     top: 100px;
     left: 50px;
 }
+
+.dropdown {
+    position: absolute;
+    text-align: left;
+    top: 200px;
+    left: 50px;
+}


### PR DESCRIPTION
I made up some shuttle data in the proper hash map format and displayed it on the Data page in a table according to the shuttle ID (the keys) selected in the dropdown menu. I also made the page responsive to change the formatting for smaller screens.

Below are screenshots of the display on iphone (it doesn't fit vertically) and macbook sized screens:
<img width="445" alt="Screenshot 2025-06-16 at 11 22 18 AM" src="https://github.com/user-attachments/assets/83075edf-12df-47a5-8cf5-e32cd502c793" />
<img width="1440" alt="Screenshot 2025-06-16 at 11 21 21 AM" src="https://github.com/user-attachments/assets/73836c49-f509-4fc3-9e79-fe9e5103f1a5" />