### PR TITLE
[Shubble Data] Typo and formatting error fixes

### DIFF
--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -32,8 +32,8 @@ export default function Data() {
 	if ("timestamp" in shuttleLocation) {
 	    let tStamp = shuttleLocation.timestamp;
 	    let hours = parseInt(tStamp.substring(11, 13));
-	    let minutes = parseInt(tStamp.substring(14, 16));
-	    let seconds = parseInt(tStamp.substring(17, 19));
+	    let minutes = tStamp.substring(14, 16);
+	    let seconds = tStamp.substring(17, 19);
 
 	    if (hours > 12) {
 		hours -= 12;


### PR DESCRIPTION
In a previous PR I added a null check on locations and displayed the message, "Locaiton (<-- typo) was set to null." In this PR I fixed that typo and also a timestamp formatting issue for times when minutes and seconds are less than 10.