### PR TITLE
[Shubble Data] Adding entry-exit message

### DIFF
--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -23,8 +23,12 @@ export default function Data() {
         }
     }
 
+    const getActiveInactive = async () => {
+    }
+
     useEffect(() => {
         fetchLocation();
+	getActiveInactive();
     }, []);
 
     useEffect(() => {
@@ -91,7 +95,7 @@ export default function Data() {
 				</tr>
 			    </thead>
 			    <tbody>
-				{[...location[selectedShuttleID]].reverse().map((shuttleLocation, index) => (
+				{[...location[selectedShuttleID].data].reverse().map((shuttleLocation, index) => (
 				    <tr key={index}>
 					<td>
 					    {formatTimestamp(shuttleLocation.timestamp)}

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -30,9 +30,7 @@ export default function Data() {
     useEffect(() => {
 	if (location != null) {
 	    if (!(selectedShuttleID in location)) {
-		console.log("Prev selectedShuttleID: " + selectedShuttleID);
 		setSelectedShuttleID(Object.keys(location)[0]);
-		console.log("New selectedShuttleID: " + selectedShuttleID);
 	    }
 	}
     }, [location]);

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -7,9 +7,9 @@ import MapKitMap from '../components/MapKitMap';
 
 export default function Data() {
 
-    const [location, setLocation] = useState(null);
+    const [shuttleData, setShuttleData] = useState(null);
 
-    const fetchLocation = async () => {
+    const fetchShuttleData = async () => {
 	try {
             const response = await fetch('/api/today');
             if (!response.ok) {
@@ -17,27 +17,23 @@ export default function Data() {
             }
             const data = await response.json();
             console.log(data);
-            setLocation(data);
+            setShuttleData(data);
         } catch (error) {
-            console.error('Error fetching location:', error);
+            console.error('Error fetching shuttleData:', error);
         }
     }
 
-    const getActiveInactive = async () => {
-    }
-
     useEffect(() => {
-        fetchLocation();
-	getActiveInactive();
+        fetchShuttleData();
     }, []);
 
     useEffect(() => {
-	if (location != null) {
-	    if (!(selectedShuttleID in location)) {
-		setSelectedShuttleID(Object.keys(location)[0]);
+	if (shuttleData != null) {
+	    if (!(selectedShuttleID in shuttleData)) {
+		setSelectedShuttleID(Object.keys(shuttleData)[0]);
 	    }
 	}
-    }, [location]);
+    }, [shuttleData]);
 
     const [selectedShuttleID, setSelectedShuttleID] = useState(null);
 
@@ -74,7 +70,7 @@ export default function Data() {
 	    <div className = "header">
 		<div className = "flex-header-reload">
 		    <h1>Shubble Data</h1>
-		    <button onClick={fetchLocation} className = "reload-button">
+		    <button onClick={fetchShuttleData} className = "reload-button">
 			<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M2 12a9 9 0 0 0 9 9c2.39 0 4.68-.94 6.4-2.6l-1.5-1.5A6.7 6.7 0 0 1 11 19c-6.24 0-9.36-7.54-4.95-11.95S18 5.77 18 12h-3l4 4h.1l3.9-4h-3a9 9 0 0 0-18 0"/></svg>
 		    </button>
 		</div>
@@ -83,11 +79,11 @@ export default function Data() {
 
 	    <div className = "table-map-sidebyside">
 		<div className = "left-screen">
-		{location ? (
+		{shuttleData ? (
 		<div>
 		    <p className = "dropdown-p-style">
 			Shuttle: <select value={selectedShuttleID} onChange={handleShuttleChange} className = "dropdown-style">
-			    {Object.keys(location).map(selectedShuttleID => (
+			    {Object.keys(shuttleData).map(selectedShuttleID => (
 				<option key={selectedShuttleID} value={selectedShuttleID}>
 				    {selectedShuttleID}
 				</option>
@@ -96,7 +92,7 @@ export default function Data() {
 		    </p>
 		    {selectedShuttleID ? (
 			<div>
-			    <p>{formatEntryExit(location[selectedShuttleID].entry, location[selectedShuttleID].exit)}</p>
+			    <p>{formatEntryExit(shuttleData[selectedShuttleID].entry, shuttleData[selectedShuttleID].exit)}</p>
 			    <div className = "location-table-overflow-scroll">
 				<table>
 				    <thead>
@@ -113,7 +109,7 @@ export default function Data() {
 					</tr>
 				    </thead>
 				    <tbody>
-					{[...location[selectedShuttleID].data].reverse().map((shuttleLocation, index) => (
+					{[...shuttleData[selectedShuttleID].data].reverse().map((shuttleLocation, index) => (
 					    <tr key={index}>
 						<td>
 						    {formatTimestamp(shuttleLocation.timestamp)}
@@ -139,7 +135,7 @@ export default function Data() {
 		    <p>No locations found</p>
 		)}
 		</div>
-		<MapKitMap vehicles={ location } />
+		<MapKitMap vehicles={ shuttleData } />
 	    </div>
 	</>
     );

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -79,39 +79,42 @@ export default function Data() {
 			</select>
 		    </p>
 		    {selectedShuttleID ? (
-		    <div className = "location-table-overflow-scroll">
-			<table>
-			    <thead>
-				<tr>
-				    <th>
-					Timestamp
-				    </th>
-				    <th>
-					Latitude, Longitude
-				    </th>
-				    <th>
-					Speed
-				    </th>
-				</tr>
-			    </thead>
-			    <tbody>
-				{[...location[selectedShuttleID].data].reverse().map((shuttleLocation, index) => (
-				    <tr key={index}>
-					<td>
-					    {formatTimestamp(shuttleLocation.timestamp)}
-					</td>
-					<td>
-					    {shuttleLocation.latitude.toFixed(3) + ", " + shuttleLocation.longitude.toFixed(3)}
-					</td>
-					<td>
-					    {shuttleLocation.speed_mph + " mph"}
-					</td>
-				    </tr>
-				))}
-				
-			    </tbody>
-			</table>
-		    </div>
+			<div>
+			    <p>Entry-Exit</p>
+			    <div className = "location-table-overflow-scroll">
+				<table>
+				    <thead>
+					<tr>
+					    <th>
+						Timestamp
+					    </th>
+					    <th>
+						Latitude, Longitude
+					    </th>
+					    <th>
+						Speed
+					    </th>
+					</tr>
+				    </thead>
+				    <tbody>
+					{[...location[selectedShuttleID].data].reverse().map((shuttleLocation, index) => (
+					    <tr key={index}>
+						<td>
+						    {formatTimestamp(shuttleLocation.timestamp)}
+						</td>
+						<td>
+						    {shuttleLocation.latitude.toFixed(3) + ", " + shuttleLocation.longitude.toFixed(3)}
+						</td>
+						<td>
+						    {shuttleLocation.speed_mph + " mph"}
+						</td>
+					    </tr>
+					))}
+					
+				    </tbody>
+				</table>
+			    </div>
+			</div>
 		    ) : (
 			<p>No shuttle selected</p>
 		    )}

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -50,19 +50,14 @@ export default function Data() {
     }
 
     function formatEntryExit(entry, exit) {
-	var entryDate = new Date(entry);
-	var exitDate = new Date(exit);
 	if (entry === null) {
 	    return "Shuttle never entered GeoFence";
 	}
-	var entryExit = entryDate.toLocaleTimeString()
-	if (exit === null) {
-	    entryExit = entryExit + "-NOW";
+	var exitStr = "NOW";
+	if (exit != null) {
+	    exitStr = new Date(exit).toLocaleString();
 	}
-	else {
-	    entryExit = entryExit + exitDate.toLocaleString()
-	}
-	return entryExit;
+	return new Date(entry).toLocaleTimeString() + "-" + exitStr;
     }
     
     return (

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -55,7 +55,7 @@ export default function Data() {
 	}
 	var exitStr = "NOW";
 	if (exit != null) {
-	    exitStr = new Date(exit).toLocaleString();
+	    exitStr = new Date(exit).toLocaleTimeString();
 	}
 	return new Date(entry).toLocaleTimeString() + "-" + exitStr;
     }

--- a/client/src/pages/Data.jsx
+++ b/client/src/pages/Data.jsx
@@ -50,7 +50,23 @@ export default function Data() {
 	    return "timestamp was set to null";
 	}
 	var timeStampDate = new Date(tStamp);
-	return timeStampDate.toLocaleString();
+	return timeStampDate.toLocaleTimeString();
+    }
+
+    function formatEntryExit(entry, exit) {
+	var entryDate = new Date(entry);
+	var exitDate = new Date(exit);
+	if (entry === null) {
+	    return "Shuttle never entered GeoFence";
+	}
+	var entryExit = entryDate.toLocaleTimeString()
+	if (exit === null) {
+	    entryExit = entryExit + "-NOW";
+	}
+	else {
+	    entryExit = entryExit + exitDate.toLocaleString()
+	}
+	return entryExit;
     }
     
     return (
@@ -80,7 +96,7 @@ export default function Data() {
 		    </p>
 		    {selectedShuttleID ? (
 			<div>
-			    <p>Entry-Exit</p>
+			    <p>{formatEntryExit(location[selectedShuttleID].entry, location[selectedShuttleID].exit)}</p>
 			    <div className = "location-table-overflow-scroll">
 				<table>
 				    <thead>

--- a/server/routes.py
+++ b/server/routes.py
@@ -136,20 +136,6 @@ def data_today():
             GeofenceEvent.event_time <= now
         )
     ).order_by(GeofenceEvent.event_time.asc()).all()
-
-    first_entry = None
-    last_entry_index = 0
-    last_exit = None
-    
-    for e, geofence_event in enumerate(events_today):
-        if geofence_event.event_type == "GeofenceEntry":
-            if first_entry == None:
-                first_entry = geofence_event.event_time
-            last_entry_index = e
-
-    for geofence_event in events_today[last_entry_index:]:
-        if geofence_event.event_type == "GeofenceExit":
-            last_exit = geofence_event.event_time
     
     locations_today_dict = {}
     for location in locations_today:
@@ -165,9 +151,29 @@ def data_today():
             locations_today_dict[location.vehicle_id]["data"].append(vehicle_location)
         else:
             locations_today_dict[location.vehicle_id] = {
-                "entry": first_entry,
-                "exit": last_exit,
+                "entry": None,
+                "exit": None,
                 "data": [vehicle_location]
             }
+
+    for vehicle_id in locations_today_dict:
+        first_entry = None
+        last_entry_index = 0
+        last_exit = None
+
+        for e, geofence_event in enumerate(events_today):
+            if geofence_event.event_type == "GeofenceEntry" and geofence_event.vehicle_id == vehicle_id:
+                if first_entry == None:
+                    first_entry = geofence_event.event_time
+                    last_entry_index = e
+
+        for geofence_event in events_today[last_entry_index:]:
+            if geofence_event.event_type == "GeofenceExit" and geofence_event.vehicle_id == vehicle_id:
+                last_exit = geofence_event.event_time
+
+        locations_today_dict[vehicle_id]["entry"] = first_entry
+        locations_today_dict[vehicle_id]["exit"] = last_exit
+
+   
     return jsonify(locations_today_dict)
-            
+

--- a/server/routes.py
+++ b/server/routes.py
@@ -141,10 +141,10 @@ def data_today():
     last_entry_index = 0
     last_exit = None
     
-    for e in range(len(events_today)):
-        if events_today[e].event_type == "GeofenceEntry":
+    for e, geofence_event in enumerate(events_today):
+        if geofence_event.event_type == "GeofenceEntry":
             if first_entry == None:
-                first_entry = events_today[e].event_time
+                first_entry = geofence_event.event_time
             last_entry_index = e
 
     i = last_entry_index

--- a/server/routes.py
+++ b/server/routes.py
@@ -172,5 +172,4 @@ def data_today():
                 "data": [vehicle_location]
             }
     return jsonify(locations_today_dict)
-    #return {"debug": str(sample_events)}
             

--- a/server/routes.py
+++ b/server/routes.py
@@ -133,6 +133,13 @@ def data_today():
         )
     ).order_by(VehicleLocation.timestamp.asc()).all()
 
+    events_today = db.session.query(GeofenceEvent).filter(
+        and_(
+            GeofenceEvent.event_time >= start_of_day,
+            GeofenceEvent.event_time <= now
+        )
+    ).order_by(GeofenceEvent.event_time.asc()).all()
+    
     locations_today_dict = {}
     for location in locations_today:
         vehicle_location = {
@@ -144,8 +151,12 @@ def data_today():
             "address_id": location.address_id
         }
         if location.vehicle_id in locations_today_dict:
-            locations_today_dict[location.vehicle_id].append(vehicle_location)
+            locations_today_dict[location.vehicle_id]["data"].append(vehicle_location)
         else:
-            locations_today_dict[location.vehicle_id] = [vehicle_location]
+            locations_today_dict[location.vehicle_id] = {
+                "entry": None,
+                "exit": None,
+                "data": [vehicle_location]
+            }
     return jsonify(locations_today_dict)
             

--- a/server/routes.py
+++ b/server/routes.py
@@ -147,11 +147,9 @@ def data_today():
                 first_entry = geofence_event.event_time
             last_entry_index = e
 
-    i = last_entry_index
-    while i < len(events_today):
-        if events_today[i].event_type == "GeofenceExit":
-            last_exit = events_today[i].event_time
-        i = i+1
+    for geofence_event in events_today[last_entry_index:]:
+        if geofence_event.event_type == "GeofenceExit":
+            last_exit = geofence_event.event_time
     
     locations_today_dict = {}
     for location in locations_today:

--- a/test/test.py
+++ b/test/test.py
@@ -110,8 +110,12 @@ def run_mock_api():
 def main():
     time.sleep(2)  # wait for main app to start
     send_webhook('281474979957434', True)
-    time.sleep(2)
+    time.sleep(60) # to test separate shuttle entrances
     send_webhook('281474993785467', True)
+    time.sleep(60) # to test exit
+    send_webhook('281474979957434', False)
+    time.sleep(60) # to test separate shuttle exits
+    send_webhook('281474993785467', False)
 
 if __name__ == '__main__':
     threading.Thread(target=main, daemon=True).start()


### PR DESCRIPTION
First I updated the backend's /api/today to include the entry and exit times in addition to the historical location data of each shuttle. This changed the format of the data returned from a dict of a list of dicts to a dict of a dict, where one key maps to a list of dicts (and the other two map to the entry and exit strings), so I adjusted the frontend accordingly by first updating all the existing code then adding an entry-exit message below the shuttle ID dropdown menu and renaming variables and functions to better describe their purpose. Below is a screenshot of a sample entry-exit message:

<img width="1440" height="780" alt="Screenshot 2025-07-22 at 6 01 57 PM" src="https://github.com/user-attachments/assets/cf60f988-bb41-46aa-9e3e-7fd3bc524f59" />