### PR TITLE
remove the mapkit endpoint

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -111,10 +111,3 @@ def webhook():
     except Exception as e:
         db.session.rollback()
         return jsonify({'status': 'error', 'message': 'Internal error'}), 500
-
-@bp.route('/api/mapkit', methods=['GET'])
-def get_mapkit():
-    api_key = os.environ.get('MAPKIT_API_KEY')
-    if not api_key:
-        return {'status': 'error', 'message': 'MAPKIT_API_KEY not set'}, 400
-    return jsonify(api_key)


### PR DESCRIPTION
The need for the mapkit endpoint was removed several versions ago. Nothing depends on the endpoint, so it's safe to remove.