### PR TITLE
feat: Verify Samsara signature in webhook route

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -14,6 +14,6 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 
     if secret := os.environ.get('SAMSARA_SECRET', None):
-        SAMSARA_SECRET = base64.b64decode(secret.encode('utf-8'), 'utf-8')
+        SAMSARA_SECRET = base64.b64decode(secret.encode('utf-8'))
     else:
         SAMSARA_SECRET = None

--- a/server/config.py
+++ b/server/config.py
@@ -1,3 +1,4 @@
+import base64
 import os
 
 class Config:
@@ -11,3 +12,8 @@ class Config:
     if SQLALCHEMY_DATABASE_URI.startswith('postgres://'):
         SQLALCHEMY_DATABASE_URI = SQLALCHEMY_DATABASE_URI.replace('postgres://', 'postgresql://', 1)
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+
+    if secret := os.environ.get('SAMSARA_SECRET', None):
+        SAMSARA_SECRET = base64.b64decode(secret.encode('utf-8'), 'utf-8')
+    else:
+        SAMSARA_SECRET = None

--- a/server/routes.py
+++ b/server/routes.py
@@ -1,10 +1,12 @@
-from flask import Blueprint, request, jsonify, send_from_directory
+from flask import Blueprint, request, jsonify, send_from_directory, current_app
 from . import db
 from .models import Vehicle, GeofenceEvent, VehicleLocation
 from pathlib import Path
 from sqlalchemy import func, and_
 from datetime import datetime, date, timezone
 from data.stops import Stops
+from hashlib import sha256
+import hmac
 import logging
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,21 @@ def get_locations():
 
 @bp.route('/api/webhook', methods=['POST'])
 def webhook():
+    if secret := current_app.config['SAMSARA_SECRET']:
+        try:
+            timestamp = request.headers['X-Samsara-Timestamp']
+            signature = request.headers['X-Samsara-Signature']
+
+            prefix = 'v1:{0}:'.format(timestamp)
+            message = bytes(prefix, 'utf-8') + request.data
+            h = hmac.new(secret, message, sha256)
+            expected_signature = 'v1=' + h.hexdigest()
+
+            if expected_signature != signature:
+                return jsonify({'status': 'error', 'message': 'Failed to authenticate request.'}), 401
+        except KeyError as e:
+            return jsonify({'status': 'error', 'message': str(e)}), 400
+
     """
     Handles incoming webhook events for geofence entries/exits.
     Expects JSON payload with event details.

--- a/server/routes.py
+++ b/server/routes.py
@@ -104,6 +104,7 @@ def get_locations():
 @bp.route('/api/webhook', methods=['POST'])
 def webhook():
     if secret := current_app.config['SAMSARA_SECRET']:
+        # See https://developers.samsara.com/docs/webhooks#webhook-signatures
         try:
             timestamp = request.headers['X-Samsara-Timestamp']
             signature = request.headers['X-Samsara-Signature']


### PR DESCRIPTION
Introduces a new environment variable `SAMSARA_SECRET` which is the webhook secret provided by Samsara dashboard.

If this variable isn't set, we do not verify the request (useful for development/debugging).

All the new imports should be in the python stdlib and should not require additional installation from pip.

Resolves #75
