### PR TITLE
fix(UI): Fix use of Schedule component in App

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -12,8 +12,11 @@ import Feedback from './components/Feedback';
 import Data from './pages/Data';
 import MapKitMap from './components/MapKitMap';
 import routeData from './data/routes.json';
+import { useState } from "react";
 
 function App() {
+  const [selectedRoute, setSelectedRoute] = useState(null);
+  const [selectedStop, setSelectedStop] = useState('all');
   return (
     <Router>
       <header>
@@ -41,7 +44,7 @@ function App() {
       <div className="App">
         <Routes>
           <Route path='/' element={<LiveLocation />} />
-          <Route path='/schedule' element={<Schedule />} />
+          <Route path='/schedule' element={<Schedule selectedRoute={selectedRoute} setSelectedRoute={setSelectedRoute} selectedStop={selectedStop} setSelectedStop={setSelectedStop}/>} />
           <Route path='/about' element={<About />} />
           <Route path='/data' element={<Data />} />
           <Route path='/generate-static-routes' element={<MapKitMap routeData={routeData} vehicles={null} generateRoutes={true} />} />

--- a/client/src/components/Schedule.jsx
+++ b/client/src/components/Schedule.jsx
@@ -4,7 +4,7 @@ import scheduleData from '../data/schedule.json';
 import routeData from '../data/routes.json';
 import { aggregatedSchedule } from '../data/parseSchedule';
 
-export default function Schedule({ selectedRoute, setSelectedRoute, selectedStop, setSelectedStop }) {
+export default function Schedule({ selectedRoute = null, setSelectedRoute = () => {}, selectedStop = null, setSelectedStop = () => {} }) {
   // Validate props once at the top
   if (typeof setSelectedRoute !== 'function') {
     throw new Error('setSelectedRoute must be a function');

--- a/client/src/components/Schedule.jsx
+++ b/client/src/components/Schedule.jsx
@@ -4,7 +4,7 @@ import scheduleData from '../data/schedule.json';
 import routeData from '../data/routes.json';
 import { aggregatedSchedule } from '../data/parseSchedule';
 
-export default function Schedule({ selectedRoute = null, setSelectedRoute = () => {}, selectedStop = null, setSelectedStop = () => {} }) {
+export default function Schedule({ selectedRoute, setSelectedRoute, selectedStop, setSelectedStop }) {
   // Validate props once at the top
   if (typeof setSelectedRoute !== 'function') {
     throw new Error('setSelectedRoute must be a function');


### PR DESCRIPTION
Ensures the Schedule component functions correctly when parent components don't explicitly pass `selectedRoute`, `setSelectedRoute`, `selectedStop`, or `setSelectedStop` props.

Fixes #129 