### PR TITLE
fix(UI): Adjusts padding for map display

### DIFF
--- a/client/src/styles/LiveLocation.css
+++ b/client/src/styles/LiveLocation.css
@@ -4,7 +4,8 @@
     gap: 40px;
     width: 100%;
     justify-content: center;
-    padding: 20px;
+    padding-top: 20px;
+    padding-bottom: 20px;
 }
 
 .schedule-table {


### PR DESCRIPTION
Addresses an issue where the map had unwanted horizontal padding.

- Modifies padding to only affect the top and bottom of the map.

Fixes #135