### PR TITLE
load shuttles on test startup - issue 110

### DIFF
--- a/test-server/server.py
+++ b/test-server/server.py
@@ -4,16 +4,75 @@ import time
 import os
 import logging
 from .shuttle import Shuttle, ShuttleState
-from datetime import datetime
+from datetime import datetime, date
+from server.models import Vehicle, GeofenceEvent, VehicleLocation
+from server.config import Config
+from sqlalchemy import func, and_
+from flask_sqlalchemy import SQLAlchemy
 import numpy as np
-
-logger = logging.getLogger(__name__)
-
-app = Flask(__name__, static_folder="../test-client/dist", static_url_path="")
 
 shuttles = {}
 shuttle_counter = 1
 shuttle_lock = Lock()
+
+logger = logging.getLogger(__name__)
+
+app = Flask(__name__, static_folder="../test-client/dist", static_url_path="")
+app.config.from_object(Config)
+
+db = SQLAlchemy()
+db.init_app(app)
+
+# setup function to populate the shuttles dict, same as in server/routes
+def setup():
+    # Start of today for filtering today's geofence events
+    start_of_today = datetime.combine(date.today(), datetime.min.time())
+
+    # Subquery: latest geofence event today per vehicle
+    # Returns a query result of (vehicle_id, event_time)
+    latest_geofence_events = db.session.query(
+        GeofenceEvent.vehicle_id,
+        func.max(GeofenceEvent.event_time).label('latest_time')
+    ).filter(
+        GeofenceEvent.event_time >= start_of_today
+    ).group_by(GeofenceEvent.vehicle_id).subquery()
+
+    # Join to get full geofence event rows where event is geofenceEntry
+    # Returns a query result of (vehicle_id, event_time, ...geofence fields including event_type)
+    geofence_entries = db.session.query(GeofenceEvent.vehicle_id).join(
+        latest_geofence_events,
+        and_(
+            GeofenceEvent.vehicle_id == latest_geofence_events.c.vehicle_id,
+            GeofenceEvent.event_time == latest_geofence_events.c.latest_time
+        )
+    ).filter(GeofenceEvent.event_type == 'geofenceEntry').subquery()
+
+    # Subquery: latest vehicle location per vehicle
+    # Returns a query result of (vehicle_id, location_time)
+    latest_locations = db.session.query(
+        VehicleLocation.vehicle_id,
+        func.max(VehicleLocation.timestamp).label('latest_time')
+    ).filter(
+        VehicleLocation.vehicle_id.in_(db.session.query(geofence_entries.c.vehicle_id))
+    ).group_by(VehicleLocation.vehicle_id).subquery()
+
+    # Join to get full location and vehicle info for vehicles in geofence
+    results = db.session.query(VehicleLocation, Vehicle).join(
+        latest_locations,
+        and_(
+            VehicleLocation.vehicle_id == latest_locations.c.vehicle_id,
+            VehicleLocation.timestamp == latest_locations.c.latest_time
+        )
+    ).join(
+        Vehicle, VehicleLocation.vehicle_id == Vehicle.id
+    ).all()
+
+    # extract vehicle information
+    for loc, vehicle in results:
+        shuttles[vehicle.id] = Shuttle(vehicle.id, loc.latitude, loc.longitude)
+
+with app.app_context():
+    setup()
 
 # --- Background Thread ---
 def update_loop():

--- a/test-server/shuttle.py
+++ b/test-server/shuttle.py
@@ -18,7 +18,7 @@ class ShuttleState(Enum):
     EXITING = "exiting"
 
 class Shuttle:
-    def __init__(self, shuttle_id: str):
+    def __init__(self, shuttle_id: str, latitude: float = 0, longitude: float = 0):
         # larger state
         self.id = shuttle_id
         self.state = ShuttleState.WAITING
@@ -26,7 +26,7 @@ class Shuttle:
 
         # shuttle properties
         self.last_updated = time.time()
-        self.location = (0, 0)
+        self.location = (latitude, longitude)
         self.speed = 0.0002
 
         self.path = []


### PR DESCRIPTION
**Describe what you are trying to do**
<!-- Are you trying to fix an issue? Implement a feature? -->
When the test suite starts up, query the database to get the shuttles currently in the geofence. Then, populate the test suite with these shuttles. Now, developers don't need to manually set up the shuttles every time they restart the test suite.

**Steps for review**
<!-- How would you like the reviewer to test your feature? -->
Add a shuttle in test server, make it enter, then reboot the test server.
On restart, the shuttle should appear in the same location as it last was.

**Issues**
<!-- Are there any existing issues? Does it close or refer to an issue -->
<!-- If close, please write `fixes #123` where 123 is the issue number. -->
<!-- If mention/refer to an issue, write `related to #123` -->
fixes #110 

**Screenshots**
<!-- For UI/logs changes -->

**Additional Information**