### PR TITLE
include polyline index in /api/locations

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -75,7 +75,7 @@ def get_locations():
     response = {}
     for loc, vehicle in results:
         # Get closest loop
-        closest_distance, _, closest_route_name, _ = Stops.get_closest_point(
+        closest_distance, _, closest_route_name, polyline_index = Stops.get_closest_point(
             (loc.latitude, loc.longitude)
         )
         if closest_distance is None:
@@ -90,6 +90,7 @@ def get_locations():
             'heading_degrees': loc.heading_degrees,
             'speed_mph': loc.speed_mph,
             'route_name': route_name,
+            'polyline_index': polyline_index,
             'is_ecu_speed': loc.is_ecu_speed,
             'formatted_location': loc.formatted_location,
             'address_id': loc.address_id,


### PR DESCRIPTION
**Describe what you are trying to do**
This includes the closest polyline index in /api/locations for the frontend to process.

**Steps for review**
Run locally, visit /api/locations and see the "polyline_index" data.

**Screenshots**
```
{
  "000000000000001": {
    "address_id": null,
    "address_name": null,
    "asset_type": "vehicle",
    "formatted_location": "Test Location",
    "gateway_model": "VG34",
    "gateway_serial": "1",
    "heading_degrees": 90.0,
    "is_ecu_speed": false,
    "latitude": 42.72981597760705,
    "license_plate": "FAKE1",
    "longitude": -73.67756439269269,
    "name": "001",
    "polyline_index": 0,
    "route_name": "WEST",
    "speed_mph": 0.0002,
    "timestamp": "2025-10-01T20:48:13",
    "vehicle_name": "1",
    "vin": "1"
  }
}
```

**Additional Information**