### PR TITLE
Uses `db.session.merge` for webhook event handling

### DIFF
--- a/server/routes.py
+++ b/server/routes.py
@@ -197,7 +197,7 @@ def webhook():
                 latitude=latitude,
                 longitude=longitude,
             )
-            db.session.add(event)
+            db.session.merge(event)
 
         db.session.commit()
         return jsonify({'status': 'success'}), 200


### PR DESCRIPTION
Updates the webhook to use `db.session.merge` instead of `db.session.add` for handling events. This ensures that existing events are updated instead of creating duplicates (basically UPSERT).

Fixes #169