### PR TITLE
[Testing] Support resetting shuttles

### DIFF
--- a/test-client/src/App.jsx
+++ b/test-client/src/App.jsx
@@ -6,12 +6,28 @@ const NEXT_STATES = ["waiting", "entering", "looping", "on_break", "exiting"];
 function App() {
   const [shuttles, setShuttles] = useState([]);
   const [selectedId, setSelectedId] = useState(null);
+  const [locationCount, setLocationCount] = useState(null);
+  const [geofenceCount, setGeofenceCount] = useState(null);
+
+  const clearEvents = async () => {
+    console.log("Clearing events...")
+    await fetch("/api/events/today", {method: "DELETE"});
+  };
+
+  const fetchEvents = async () => {
+    const res = await fetch("/api/events/today");
+    const data = await res.json();
+    console.log(data);
+    setLocationCount(data.locationCount);
+    setGeofenceCount(data.geofenceCount);
+  }
 
   const fetchShuttles = async () => {
     const res = await fetch("/api/shuttles");
     const data = await res.json();
     setShuttles(data);
     console.log("Fetched shuttles:", data);
+    await fetchEvents();
   };
 
   const addShuttle = async () => {
@@ -96,6 +112,11 @@ function App() {
       ) : (
         <p>No shuttle selected.</p>
       )}
+
+      <div className="today-events">
+        {locationCount} previous shuttle locations and {geofenceCount} previous entry/exit events
+      </div>
+      <button onclick={clearEvents}>Clear Events</button>
     </div>
   );
 }

--- a/test-client/src/App.jsx
+++ b/test-client/src/App.jsx
@@ -10,14 +10,13 @@ function App() {
   const [geofenceCount, setGeofenceCount] = useState(null);
 
   const clearEvents = async () => {
-    console.log("Clearing events...")
     await fetch("/api/events/today", {method: "DELETE"});
+    console.log("Cleared events for today");
   };
 
   const fetchEvents = async () => {
     const res = await fetch("/api/events/today");
     const data = await res.json();
-    console.log(data);
     setLocationCount(data.locationCount);
     setGeofenceCount(data.geofenceCount);
   }
@@ -27,7 +26,6 @@ function App() {
     const data = await res.json();
     setShuttles(data);
     console.log("Fetched shuttles:", data);
-    await fetchEvents();
   };
 
   const addShuttle = async () => {
@@ -47,6 +45,12 @@ function App() {
     });
     await fetchShuttles();
   };
+
+  useEffect(() => {
+    fetchEvents();
+    const interval = setInterval(fetchEvents, 1000);
+    return () => clearInterval(interval);
+  }, []);
 
   useEffect(() => {
     fetchShuttles();
@@ -113,10 +117,12 @@ function App() {
         <p>No shuttle selected.</p>
       )}
 
-      <div className="today-events">
-        {locationCount} previous shuttle locations and {geofenceCount} previous entry/exit events
+      <div className="events-container">
+        <div className="events-today">
+          {locationCount} previous shuttle locations and {geofenceCount} previous entry/exit events
+        </div>
+        <button onClick={clearEvents}>Clear Events</button>
       </div>
-      <button onclick={clearEvents}>Clear Events</button>
     </div>
   );
 }

--- a/test-client/src/App.jsx
+++ b/test-client/src/App.jsx
@@ -6,20 +6,9 @@ const NEXT_STATES = ["waiting", "entering", "looping", "on_break", "exiting"];
 function App() {
   const [shuttles, setShuttles] = useState([]);
   const [selectedId, setSelectedId] = useState(null);
-  const [locationCount, setLocationCount] = useState(null);
-  const [geofenceCount, setGeofenceCount] = useState(null);
-
-  const clearEvents = async () => {
-    await fetch("/api/events/today", {method: "DELETE"});
-    console.log("Cleared events for today");
-  };
-
-  const fetchEvents = async () => {
-    const res = await fetch("/api/events/today");
-    const data = await res.json();
-    setLocationCount(data.locationCount);
-    setGeofenceCount(data.geofenceCount);
-  }
+  const [locationCount, setLocationCount] = useState(0);
+  const [geofenceCount, setGeofenceCount] = useState(0);
+  const [keepShuttles, setKeepShuttles] = useState(false);
 
   const fetchShuttles = async () => {
     const res = await fetch("/api/shuttles");
@@ -44,6 +33,21 @@ function App() {
       body: JSON.stringify({ state: nextState }),
     });
     await fetchShuttles();
+  };
+
+  const fetchEvents = async () => {
+    const res = await fetch("/api/events/today");
+    const data = await res.json();
+    setLocationCount(data.locationCount);
+    setGeofenceCount(data.geofenceCount);
+  }
+
+  const clearEvents = async () => {
+    await fetch(`/api/events/today?keepShuttles=${keepShuttles}`, {method: "DELETE"});
+    if (!keepShuttles) {
+      setSelectedId(null);
+    }
+    console.log("Cleared events for today");
   };
 
   useEffect(() => {
@@ -122,6 +126,14 @@ function App() {
           {locationCount} previous shuttle locations and {geofenceCount} previous entry/exit events
         </div>
         <button onClick={clearEvents}>Clear Events</button>
+        <label>
+          <input
+            type="checkbox"
+            checked={keepShuttles}
+            onChange={(e) => setKeepShuttles(e.target.checked)}
+          />
+          Keep Shuttles
+        </label>
       </div>
     </div>
   );

--- a/test-client/src/index.css
+++ b/test-client/src/index.css
@@ -54,6 +54,10 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+.events-container {
+  margin-top: 25px;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/test-server/server.py
+++ b/test-server/server.py
@@ -91,15 +91,22 @@ t.start()
 # --- API Routes ---
 @app.route("/api/events/today", methods=["GET"])
 def get_todays_events():
-    #start_of_today = datetime.combine(date.today(), datetime.min.time())
+    start_of_today = datetime.combine(date.today(), datetime.min.time())
+    loc_count = db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).count()
+    geo_count = db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).count()
     return jsonify({
-        'locationCount': 9999,
-        'geofenceCount': 1234
+        'locationCount': loc_count,
+        'geofenceCount': geo_count
     })
 
 @app.route("/api/events/today", methods=["DELETE"])
 def clear_todays_events():
-    pass
+    start_of_today = datetime.combine(date.today(), datetime.min.time())
+    db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).delete()
+    db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).delete()
+    db.session.commit()
+    logger.info(f"Deleted location and geofence events past {start_of_today}")
+    return "", 204
 
 @app.route("/api/shuttles", methods=["GET"])
 def list_shuttles():

--- a/test-server/server.py
+++ b/test-server/server.py
@@ -89,25 +89,6 @@ t = Thread(target=update_loop, daemon=True)
 t.start()
 
 # --- API Routes ---
-@app.route("/api/events/today", methods=["GET"])
-def get_todays_events():
-    start_of_today = datetime.combine(date.today(), datetime.min.time())
-    loc_count = db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).count()
-    geo_count = db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).count()
-    return jsonify({
-        'locationCount': loc_count,
-        'geofenceCount': geo_count
-    })
-
-@app.route("/api/events/today", methods=["DELETE"])
-def clear_todays_events():
-    start_of_today = datetime.combine(date.today(), datetime.min.time())
-    db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).delete()
-    db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).delete()
-    db.session.commit()
-    logger.info(f"Deleted location and geofence events past {start_of_today}")
-    return "", 204
-
 @app.route("/api/shuttles", methods=["GET"])
 def list_shuttles():
     with shuttle_lock:
@@ -140,6 +121,69 @@ def trigger_action(shuttle_id):
         shuttle.set_next_state(desired_state)
         logger.info(f"Set shuttle {shuttle_id} next state to {next_state}")
         return jsonify(shuttle.to_dict())
+
+@app.route("/api/events/today", methods=["GET"])
+def get_events_today():
+    start_of_today = get_campus_start_of_day()
+    loc_count = db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).count()
+    geo_count = db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).count()
+    return jsonify({
+        'locationCount': loc_count,
+        'geofenceCount': geo_count
+    })
+
+@app.route("/api/events/today", methods=["DELETE"])
+def clear_events_today():
+    keep_shuttles = request.args.get("keepShuttles", "false").lower() == "true"
+    start_of_today = get_campus_start_of_day()
+
+    db.session.query(VehicleLocation).filter(VehicleLocation.timestamp >= start_of_today).delete()
+    logger.info(f"Deleted vehicle location events past {start_of_today}")
+
+    if not keep_shuttles:
+        db.session.query(GeofenceEvent).filter(GeofenceEvent.event_time >= start_of_today).delete()
+        logger.info(f"Deleted geofence events past {start_of_today}")
+
+        global shuttle_counter
+        with shuttle_lock:
+            shuttles.clear()
+            shuttle_counter = 1
+        logger.info(f"Deleted all shuttles")
+    else:
+        '''
+        Delete all geofence events >= start_of_today except for: each vehicle's latest one (if it
+        is a geofenceEntry. geofenceExits are still deleted). This allows all currently running
+        shuttles to keep running in the test suite.
+        '''
+
+        # Get today's geofence events
+        today_events = db.session.query(GeofenceEvent).filter(
+            GeofenceEvent.event_time >= start_of_today
+        ).subquery()
+        # Get latest event per vehicle from today's geofence events
+        latest_times = db.session.query(
+            today_events.c.vehicle_id,
+            func.max(today_events.c.event_time).label("latest_time")
+        ).group_by(today_events.c.vehicle_id).subquery()
+        # Join back to get the full event row, select to keep only geofenceEntry, project on id
+        latest_entries = db.session.query(today_events.c.id).join(
+            latest_times,
+            and_(
+                today_events.c.vehicle_id == latest_times.c.vehicle_id,
+                today_events.c.event_time == latest_times.c.latest_time
+            )
+        ).filter(today_events.c.event_type == 'geofenceEntry').subquery()
+        # Delete all in today_events that aren't in latest_entries
+        db.session.query(GeofenceEvent).filter(
+            GeofenceEvent.id.in_(db.session.query(today_events.c.id))
+        ).filter(
+            ~GeofenceEvent.id.in_(db.session.query(latest_entries.c.id))
+        ).delete()
+
+        logger.info(f"Deleted geofence events past {start_of_today} except for currently running shuttles")
+
+    db.session.commit()
+    return "", 204
 
 # --- Frontend Serving ---
 @app.route("/")

--- a/test-server/server.py
+++ b/test-server/server.py
@@ -89,6 +89,18 @@ t = Thread(target=update_loop, daemon=True)
 t.start()
 
 # --- API Routes ---
+@app.route("/api/events/today", methods=["GET"])
+def get_todays_events():
+    #start_of_today = datetime.combine(date.today(), datetime.min.time())
+    return jsonify({
+        'locationCount': 9999,
+        'geofenceCount': 1234
+    })
+
+@app.route("/api/events/today", methods=["DELETE"])
+def clear_todays_events():
+    pass
+
 @app.route("/api/shuttles", methods=["GET"])
 def list_shuttles():
     with shuttle_lock:


### PR DESCRIPTION
**Describe what you are trying to do**
<!-- Are you trying to fix an issue? Implement a feature? -->
Adds functionality to clear all location and geofence events for the day.
Also adds the option to keep currently running shuttles.

**Steps for review**
<!-- How would you like the reviewer to test your feature? -->
- Start test suite
- Add shuttles, set entering
- Verify that the location/geofence event counters work
- Clear data with the "keep shuttles" box unchecked
- Verify that all data is deleted for today only, and that the shuttles have been reset
- Add shuttles, set entering
- Clear data with "keep shuttles" checked
- Verify that all data for today has been deleted, except for the latest geofenceEntry for shuttles currently in the geofence
- Verify that the shuttles have not been reset

**Issues**
<!-- Are there any existing issues? Does it close or refer to an issue -->
<!-- If close, please write `fixes #123` where 123 is the issue number. -->
<!-- If mention/refer to an issue, write `related to #123` -->
fixes issue #111

**Screenshots**
<!-- For UI/logs changes -->
<img width="331" height="50" alt="image" src="https://github.com/user-attachments/assets/9cdd96e1-ab9c-4786-91eb-be583b180cfe" />

**Additional Information**