### PR TITLE
Fix backend error when running the worker

### DIFF
--- a/server/config.py
+++ b/server/config.py
@@ -1,6 +1,9 @@
 import base64
+from dotenv import load_dotenv
 import os
 from zoneinfo import ZoneInfo
+
+load_dotenv()
 
 
 class Config:


### PR DESCRIPTION
When you run the backend worker in Windows, you can an error along the lines of:

raceback (most recent call last):
  File "<frozen runpy>", line 189, in _run_module_as_main
  File "<frozen runpy>", line 112, in _get_module_details
  File "C:\Users\polib\shubble\server\__init__.py", line 5, in <module>
    from .config import Config
  File "C:\Users\polib\shubble\server\config.py", line 6, in <module>
    class Config:
  File "C:\Users\polib\shubble\server\config.py", line 14, in Config
    if SQLALCHEMY_DATABASE_URI.startswith('postgres://'):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'startswith'

Fixed the error so python -m server.worker works fine.
