### PR TITLE
fix(pwa): Excludes API routes from service worker navigation

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'robots.txt'],
+      workbox: {
+        navigateFallbackDenylist: [/^\/api/]
+      },
       manifest: {
         name: "Shubble Web App",
         short_name: "Shubble",


### PR DESCRIPTION
**Describe what you are trying to do**

This change ensures that API routes are not handled by the service worker's navigation fallback, preventing potential conflicts.

**Steps for review**

1. Verify that navigating to API routes (e.g., `/api/*`) correctly hits the server and is not intercepted by the service worker.
2. Ensure that other navigation requests are still handled by the service worker's fallback as expected.

**Issues**



fixes #199

**Screenshots**


**Additional Information**