### PR TITLE
Adds E-Complex stop to West route

### DIFF
--- a/data/routes.json
+++ b/data/routes.json
@@ -659,6 +659,7 @@
       "CHASAN",
       "FEDERAL_6TH",
       "WEST_HALL",
+      "E_COMPLEX",
       "STUDENT_UNION_RETURN"
     ],
     "POLYLINE_STOPS": [
@@ -672,6 +673,7 @@
       "GHOST_STOP_2",
       "FEDERAL_6TH",
       "WEST_HALL",
+      "E_COMPLEX",
       "STUDENT_UNION_RETURN"
     ],
     "STUDENT_UNION": {
@@ -753,6 +755,14 @@
       ],
       "OFFSET": 15,
       "NAME": "West Hall"
+    },
+    "E_COMPLEX": {
+      "COORDINATES": [
+        42.731060,
+        -73.679268
+      ],
+      "OFFSET": 16,
+      "NAME": "E-Complex"
     },
     "STUDENT_UNION_RETURN": {
       "COORDINATES": [


### PR DESCRIPTION
**Describe what you are trying to do**

Adds the E-Complex stop to the West route.

**Steps for review**

Verify that the West route now includes the E-Complex stop in the correct sequence.

**Issues**




**Screenshots**


**Additional Information**

The location the shuttle stops at this point seems to vary, but there certainly does seem to be a stop here, despite it not being labeled on the RPI Admin website. The poly line should be the same because it is along sage avenue.