### PR TITLE
fixed windows compatability for parseSchedule.js path handling

### DIFF
--- a/shared/parseSchedule.js
+++ b/shared/parseSchedule.js
@@ -1,6 +1,7 @@
 import { timeToDate } from './timeUtils.js';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import scheduleData from './schedule.json' with { type: 'json' };
 
 function aggregateSchedule(scheduleData) {
@@ -45,6 +46,8 @@ function aggregateSchedule(scheduleData) {
 const aggregatedSchedule = aggregateSchedule(scheduleData);
 
 // Write to the shared directory (where this script is located)
-const outputPath = path.join(path.dirname(new URL(import.meta.url).pathname), 'aggregated_schedule.json');
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const outputPath = path.join(__dirname, 'aggregated_schedule.json');
 fs.writeFileSync(outputPath, JSON.stringify(aggregatedSchedule, null, 2));
 console.log(`aggregatedSchedule.json generated at ${outputPath}`);


### PR DESCRIPTION
**Describe what you are trying to do**
When running npm run dev for the front end on windows, 
<img width="1039" height="378" alt="image" src="https://github.com/user-attachments/assets/e2766b0c-504a-4851-a82f-bfc211a36461" />
the path.join dupliates the "C:\\" in the path for windows as you can see in the image , causing an error. I used fileURLtoPath instead of url.pathname to handle windows drive letters correctly. 

**Steps for review**
Check this works both on Mac and another Windows device to double check
