### PR TITLE
Comment out healthcheck (temporary)

### DIFF
--- a/docker/backend/Dockerfile.backend.prod
+++ b/docker/backend/Dockerfile.backend.prod
@@ -45,8 +45,8 @@ ENV PATH="/app/.venv/bin:$PATH"
 EXPOSE 8000
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
-    CMD python -c "import httpx; httpx.get('http://localhost:8000/api/locations', timeout=5.0)"
+# HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
+    # CMD python -c "import httpx; httpx.get('http://localhost:8000/api/locations', timeout=5.0)"
 
 # Run database migrations and start uvicorn with workers
 CMD ["sh", "-c", "alembic -c backend/alembic.ini upgrade head && exec uvicorn shubble:app --host 0.0.0.0 --port 8000 --workers 2"]


### PR DESCRIPTION
We're having an issue where the backend is repeatedly restarting periodically. I suspect that it may be due to a slow startup, which causes it to fail the healthcheck, thereby causing Dokploy to restart it. This PR tests that.