### PR TITLE
Fix config to build on npm run dev and add option to show static etas

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       BACKEND_URL: ${BACKEND_URL:-http://localhost:8000}
       DEPLOY_MODE: ${DEPLOY_MODE:-development}
       MAPKIT_KEY: ${MAPKIT_KEY:-}
+      STATIC_ETAS: ${STATIC_ETAS:-false}
     restart: unless-stopped
     volumes:
       - ./frontend:/app/frontend

--- a/docker/frontend/.env.example
+++ b/docker/frontend/.env.example
@@ -2,3 +2,4 @@
 BACKEND_URL=http://localhost:8000
 DEPLOY_MODE=development
 MAPKIT_KEY=
+STATIC_ETAS=false

--- a/frontend/config.template.json
+++ b/frontend/config.template.json
@@ -1,5 +1,6 @@
 {
   "apiBaseUrl": "${BACKEND_URL}",
   "deployMode": "${DEPLOY_MODE}",
-  "mapkitKey": "${MAPKIT_KEY}"
+  "mapkitKey": "${MAPKIT_KEY}",
+  "staticETAs": "${STATIC_ETAS}"
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "node ../shared/parseSchedule.js && shx cp -r ../shared/ src/ && vite",
-    "build": "node ../shared/parseSchedule.js && shx cp -r ../shared/ src/ && vite build",
+    "dev": "node scripts/generate-config.js && node ../shared/parseSchedule.js && shx cp -r ../shared/ src/ && vite",
+    "build": "node scripts/generate-config.js && node ../shared/parseSchedule.js && shx cp -r ../shared/ src/ && vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/frontend/public/.gitignore
+++ b/frontend/public/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/frontend/public/config.json
+++ b/frontend/public/config.json
@@ -1,4 +1,0 @@
-{
-  "apiBaseUrl": "http://localhost:8000",
-  "deployMode": "development"
-}

--- a/frontend/scripts/generate-config.js
+++ b/frontend/scripts/generate-config.js
@@ -1,0 +1,39 @@
+// Generate public/config.json from environment variables.
+// Used by `npm run dev` and `npm run build` for local and Docker dev.
+// In production, this is handled by envsubst in docker/frontend/entrypoint.sh instead.
+
+import { readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load .env from repo root (env vars already set in the process take precedence)
+try {
+  const envFile = readFileSync(join(__dirname, '..', '..', '.env'), 'utf-8');
+  for (const line of envFile.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) continue;
+    const key = trimmed.slice(0, eqIndex);
+    const value = trimmed.slice(eqIndex + 1);
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+} catch {
+  // .env file is optional
+}
+
+const config = {
+  apiBaseUrl: process.env.BACKEND_URL || 'http://localhost:8000',
+  deployMode: process.env.DEPLOY_MODE || 'development',
+  mapkitKey: process.env.MAPKIT_KEY || '',
+  staticETAs: process.env.STATIC_ETAS === 'true'
+};
+
+writeFileSync(
+  join(__dirname, '..', 'public', 'config.json'),
+  JSON.stringify(config, null, 2) + '\n'
+);

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -3,12 +3,14 @@ interface Config {
     isDev: boolean;
     apiBaseUrl: string;
     mapkitKey: string;
+    staticETAs: boolean;
 }
 
 type ConfigJSON = {
     deployMode?: string;
     apiBaseUrl?: string;
     mapkitKey?: string;
+    staticETAs?: boolean | string;
 }
 
 let config: Config | null = null;
@@ -28,7 +30,8 @@ export async function loadConfig(): Promise<Config> {
             isStaging,
             isDev: isStaging,
             apiBaseUrl: json.apiBaseUrl || 'http://localhost:8000',
-            mapkitKey: json.mapkitKey || ''
+            mapkitKey: json.mapkitKey || '',
+            staticETAs: json.staticETAs === true || json.staticETAs === 'true'
         };
     } catch {
         // Fallback for local development without config.json
@@ -36,7 +39,8 @@ export async function loadConfig(): Promise<Config> {
             isStaging: true,
             isDev: true,
             apiBaseUrl: 'http://localhost:8000',
-            mapkitKey: import.meta.env.VITE_MAPKIT_KEY as string || ''
+            mapkitKey: import.meta.env.VITE_MAPKIT_KEY as string || '',
+            staticETAs: import.meta.env.VITE_STATIC_ETAS === 'true'
         };
     }
 
@@ -54,5 +58,6 @@ export default {
     get isStaging() { return getConfig().isStaging; },
     get isDev() { return getConfig().isDev; },
     get apiBaseUrl() { return getConfig().apiBaseUrl; },
-    get mapkitKey() { return getConfig().mapkitKey; }
+    get mapkitKey() { return getConfig().mapkitKey; },
+    get staticETAs() { return getConfig().staticETAs; }
 };

--- a/shared/routes.json
+++ b/shared/routes.json
@@ -110,7 +110,7 @@
         42.730711,
         -73.676737
       ],
-      "OFFSET": 16,
+      "OFFSET": 15,
       "NAME": "Student Union (Return)"
     },
     "ROUTES": [
@@ -687,7 +687,7 @@
         42.727985,
         -73.678
       ],
-      "OFFSET": 3,
+      "OFFSET": 2,
       "NAME": "Academy Hall"
     },
     "POLYTECHNIC": {
@@ -695,7 +695,7 @@
         42.722903,
         -73.679567
       ],
-      "OFFSET": 5,
+      "OFFSET": 3,
       "NAME": "Polytechnic"
     },
     "GHOST_STOP_1": {
@@ -703,7 +703,7 @@
         42.72778967727594,
         -73.68846611973184
       ],
-      "OFFSET": 8,
+      "OFFSET": 5,
       "NAME": "5th Ave & Ferry St"
     },
     "CITY_STATION": {
@@ -711,7 +711,7 @@
         42.727673,
         -73.687228
       ],
-      "OFFSET": 9,
+      "OFFSET": 7,
       "NAME": "City Station"
     },
     "BLITMAN": {
@@ -719,7 +719,7 @@
         42.730733889768935,
         -73.68654871130366
       ],
-      "OFFSET": 11,
+      "OFFSET": 8,
       "NAME": "Blitman"
     },
     "CHASAN": {
@@ -727,7 +727,7 @@
         42.73113007261683,
         -73.68883082757004
       ],
-      "OFFSET": 13,
+      "OFFSET": 9,
       "NAME": "Chasan Building"
     },
     "FEDERAL_6TH": {
@@ -735,7 +735,7 @@
         42.73358721710756,
         -73.68574634740555
       ],
-      "OFFSET": 14,
+      "OFFSET": 11,
       "NAME": "Federal & 6th"
     },
     "GHOST_STOP_2": {
@@ -743,7 +743,7 @@
         42.732217914196276,
         -73.68715498765913
       ],
-      "OFFSET": 15,
+      "OFFSET": 13,
       "NAME": "Fulton St"
     },
     "WEST_HALL": {
@@ -751,7 +751,7 @@
         42.73155332161482,
         -73.68135702064839
       ],
-      "OFFSET": 15,
+      "OFFSET": 13,
       "NAME": "West Hall"
     },
     "STUDENT_UNION_RETURN": {
@@ -759,7 +759,7 @@
         42.73030957936359,
         -73.67653679162925
       ],
-      "OFFSET": 17,
+      "OFFSET": 15,
       "NAME": "Student Union (Return)"
     },
     "ROUTES": [


### PR DESCRIPTION
**Describe what you are trying to do**
- When developers run npm run dev, generate config.json with the latest environment variables
- Add support for an environment variable that switches the frontend to use static eta offsets