### PR TITLE
perf: change ORM relationships to lazy load instead of eager load

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -19,11 +19,13 @@ class Vehicle(Base):
     gateway_serial: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
     # Relationships
-    geofence_events: Mapped[list["GeofenceEvent"]] = relationship(back_populates="vehicle", lazy="selectin")
-    locations: Mapped[list["VehicleLocation"]] = relationship(back_populates="vehicle", lazy="selectin")
-    driver_assignments: Mapped[list["DriverVehicleAssignment"]] = relationship(back_populates="vehicle", lazy="selectin")
-    etas: Mapped[list["ETA"]] = relationship(back_populates="vehicle", lazy="selectin")
-    predicted_locations: Mapped[list["PredictedLocation"]] = relationship(back_populates="vehicle", lazy="selectin")
+    # lazy="raise" prevents accidental N+1 queries. Use explicit
+    # selectinload()/joinedload() in queries that need related objects.
+    geofence_events: Mapped[list["GeofenceEvent"]] = relationship(back_populates="vehicle", lazy="raise")
+    locations: Mapped[list["VehicleLocation"]] = relationship(back_populates="vehicle", lazy="raise")
+    driver_assignments: Mapped[list["DriverVehicleAssignment"]] = relationship(back_populates="vehicle", lazy="raise")
+    etas: Mapped[list["ETA"]] = relationship(back_populates="vehicle", lazy="raise")
+    predicted_locations: Mapped[list["PredictedLocation"]] = relationship(back_populates="vehicle", lazy="raise")
 
     def __repr__(self):
         return f"<Vehicle {self.id} - {self.name}>"
@@ -88,7 +90,7 @@ class Driver(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
 
     # Relationships
-    assignments: Mapped[list["DriverVehicleAssignment"]] = relationship(back_populates="driver", lazy="selectin")
+    assignments: Mapped[list["DriverVehicleAssignment"]] = relationship(back_populates="driver", lazy="raise")
 
     def __repr__(self):
         return f"<Driver {self.id} - {self.name}>"


### PR DESCRIPTION
**Describe what you are trying to do**
<!-- Are you trying to fix an issue? Implement a feature? -->
Fix slow /api/locations response times on cache miss. The Vehicle and Driver ORM models had all their relationships configured with lazy="selectin", which is an eager loading strategy. This means every time a Vehicle object was loaded via ORM (e.g. in get_latest_vehicle_locations()), SQLAlchemy automatically fired 5 extra SELECT ... WHERE vehicle_id IN (...) queries to populate geofence_events, locations, driver_assignments, etas, and predicted_locations — none of which are ever read by any code path.

This changes all 6 relationships to lazy="raise", which skips the automatic queries entirely. If any future code accidentally tries to access an unloaded relationship, it will raise InvalidRequestError instead of silently issuing a query — acting as a guardrail against N+1 regressions.

All existing code that actually needs related data already uses explicit selectinload() at the query level (e.g. selectinload(VehicleLocation.vehicle), selectinload(DriverVehicleAssignment.driver)), so those code paths are unaffected.

**Steps for review**
<!-- How would you like the reviewer to test your feature? -->

**Issues**
<!-- Are there any existing issues? Does it close or refer to an issue -->
<!-- If close, please write `fixes #123` where 123 is the issue number. -->
<!-- If mention/refer to an issue, write `related to #123` -->

**Screenshots**
<!-- For UI/logs changes -->

**Additional Information**
https://docs.sqlalchemy.org/en/14/orm/loading_relationships.html