### PR TITLE
Filter latest locations by today

### DIFF
--- a/backend/fastapi/utils.py
+++ b/backend/fastapi/utils.py
@@ -10,6 +10,7 @@ from backend.function_timer import timed
 from backend.models import VehicleLocation, DriverVehicleAssignment, ETA, PredictedLocation
 from backend.cache_dataframe import get_today_dataframe
 from backend.utils import get_vehicles_in_geofence_query
+from backend.time_utils import get_campus_start_of_day
 
 import logging
 
@@ -168,7 +169,8 @@ async def get_latest_vehicle_locations(session_factory) -> List[VehicleLocationD
         query = (
             select(VehicleLocation)
             .where(
-                VehicleLocation.vehicle_id.in_(select(geofence_entries.c.vehicle_id))
+                VehicleLocation.vehicle_id.in_(select(geofence_entries.c.vehicle_id)),
+                VehicleLocation.timestamp >= get_campus_start_of_day(),
             )
             .order_by(
                 VehicleLocation.vehicle_id,


### PR DESCRIPTION
**Describe what you are trying to do**
Getting the latest locations currently requires considering all rows and either:
- Grouping by vehicle id and finding the max timestamp (old approach)
- Ordering by timestamp and taking the last entry for each distinct vehicle id (new approach)

Either way, the queries consider all rows, but we know that the latest vehicle location must be from today (we already filter the geofence events by today, so this doesn't place any additional restrictions).

This change adds the filter for today's locations to the WHERE clause, which should bound the query time as the database grows.

**Steps for review**
Run the test suite.