### PR TITLE
Proxy the frontend/backend

### DIFF
--- a/backend/fastapi/__init__.py
+++ b/backend/fastapi/__init__.py
@@ -55,6 +55,9 @@ def create_app() -> FastAPI:
         description="Shuttle tracking API for Shubble",
         version="2.0.0",
         lifespan=lifespan,
+        docs_url="/api/docs",
+        redoc_url="/api/redoc",
+        openapi_url="/api/openapi.json",
     )
 
     # Configure CORS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
     ports:
       - "${FRONTEND_PORT:-3000}:3000"
     environment:
-      BACKEND_URL: ${BACKEND_URL:-http://localhost:8000}
+      BACKEND_URL: ${BACKEND_URL:-http://backend:8000}
       DEPLOY_MODE: ${DEPLOY_MODE:-development}
       MAPKIT_KEY: ${MAPKIT_KEY:-}
       STATIC_ETAS: ${STATIC_ETAS:-false}

--- a/docker/backend/Dockerfile.backend.prod
+++ b/docker/backend/Dockerfile.backend.prod
@@ -49,4 +49,4 @@ EXPOSE 8000
     # CMD python -c "import httpx; httpx.get('http://localhost:8000/api/locations', timeout=5.0)"
 
 # Run database migrations and start uvicorn with workers
-CMD ["sh", "-c", "alembic -c backend/alembic.ini upgrade head && exec uvicorn shubble:app --host 0.0.0.0 --port 8000 --workers 6"]
+CMD ["sh", "-c", "alembic -c backend/alembic.ini upgrade head && exec uvicorn shubble:app --host 0.0.0.0 --port 8000 --workers 2"]

--- a/docker/frontend/.env.example
+++ b/docker/frontend/.env.example
@@ -1,5 +1,7 @@
 # Frontend service environment variables
-BACKEND_URL=http://localhost:8000
+# Empty = same-domain (nginx proxies /api/ to backend container).
+# Override with http://backend:8000 only if the Vite dev server needs it explicitly.
+BACKEND_URL=
 DEPLOY_MODE=development
 MAPKIT_KEY=
 STATIC_ETAS=false

--- a/docker/frontend/nginx.conf
+++ b/docker/frontend/nginx.conf
@@ -8,6 +8,16 @@ server {
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
 
+    # Proxy API requests to backend
+    location /api/ {
+        proxy_pass http://backend:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 60s;
+    }
+
     # Handle SPA routing
     location / {
         try_files $uri $uri/ /index.html;

--- a/frontend/config.template.json
+++ b/frontend/config.template.json
@@ -1,5 +1,5 @@
 {
-  "apiBaseUrl": "${BACKEND_URL}",
+  "apiBaseUrl": "",
   "deployMode": "${DEPLOY_MODE}",
   "mapkitKey": "${MAPKIT_KEY}",
   "staticETAs": "${STATIC_ETAS}"

--- a/frontend/scripts/generate-config.js
+++ b/frontend/scripts/generate-config.js
@@ -27,7 +27,7 @@ try {
 }
 
 const config = {
-  apiBaseUrl: process.env.BACKEND_URL || 'http://localhost:8000',
+  apiBaseUrl: '',
   deployMode: process.env.DEPLOY_MODE || 'development',
   mapkitKey: process.env.MAPKIT_KEY || '',
   staticETAs: process.env.STATIC_ETAS === 'true'

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -29,7 +29,7 @@ export async function loadConfig(): Promise<Config> {
         config = {
             isStaging,
             isDev: isStaging,
-            apiBaseUrl: json.apiBaseUrl || 'http://localhost:8000',
+            apiBaseUrl: json.apiBaseUrl ?? '',
             mapkitKey: json.mapkitKey || '',
             staticETAs: json.staticETAs === true || json.staticETAs === 'true'
         };
@@ -38,7 +38,7 @@ export async function loadConfig(): Promise<Config> {
         config = {
             isStaging: true,
             isDev: true,
-            apiBaseUrl: 'http://localhost:8000',
+            apiBaseUrl: '',
             mapkitKey: import.meta.env.VITE_MAPKIT_KEY as string || '',
             staticETAs: import.meta.env.VITE_STATIC_ETAS === 'true'
         };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,7 +4,13 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
   server: {
-    port: 3000
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: process.env.BACKEND_URL || 'http://localhost:8000',
+        changeOrigin: true,
+      }
+    }
   },
   plugins: [
     react(),


### PR DESCRIPTION
**Describe what you are trying to do**
Currently, the frontend and backend are hosted on different domains. It would be great if they could be hosted on the same domain, with the backend at /api/ to deconflict the two. This would make it easier to configure and simplify the Cross-Origin settings.

**Steps for review**
Run the test suite, same as usual, but just visit `http://localhost:3000` and `http://localhost:3000/api/docs`.

**Issues**
Fixes #274 